### PR TITLE
Log "no face found" as info (not as warning)

### DIFF
--- a/api/src/util/detectors/aiserver.js
+++ b/api/src/util/detectors/aiserver.js
@@ -64,8 +64,15 @@ module.exports.remove = ({ name }) => {
 
 module.exports.normalize = ({ camera, data }) => {
   if (!data.success) {
-    console.warn('unexpected ai.server data');
-    return [];
+    // compare with CoderProjectAI sources
+    // https://github.com/codeproject/CodeProject.AI-Server/blob/main/src/modules/FaceProcessing/intelligencelayer/face.py#L528
+    if (data.code === 500 && data.error === 'No face found in image') {
+      console.log('ai.server found no face in image');
+      return [];
+    } else {
+      console.warn('unexpected ai.server data');
+      return [];
+    }
   }
   const { MATCH, UNKNOWN } = config.detect(camera);
   if (!data.predictions) {


### PR DESCRIPTION
while I was trying to learn how to use double-take, I came across this very minor issue - but for what ever reason I could not resist to create a PR in order to allow others to understand the generated log output a bit better