### PR TITLE
Adding some webp handling to work with frigate >=0.14

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "socket.io": "^4.6.2",
     "traverse": "^0.6.6",
     "uuid": "^9.0.0",
-    "winston": "^3.7.2"
+    "winston": "^3.7.2",
+    "webp-wasm": "^1.0.4"
   }
 }

--- a/api/src/util/process.util.js
+++ b/api/src/util/process.util.js
@@ -193,7 +193,7 @@ module.exports.process = async ({ camera, detector, tmp, errors }) => {
 };
 
 module.exports.isValidURL = async ({ auth = false, type, url }) => {
-  const validOptions = ['image/jpg', 'image/jpeg', 'image/png'];
+  const validOptions = ['image/jpg', 'image/jpeg', 'image/png', 'image/webp'];
   try {
     const isDigest = digest.exists(url) || auth === 'digest';
     const digestAuth = isDigest ? digest(parse.url(url)) : false;


### PR DESCRIPTION
Not exactly sure you would want it handled like that : trial and fail method with webp fallback.
My understanding is that frigate would completely move to webp at some point.

I'm using compreface so work out of the bow with webp, not sure if this is the case with other backends : tested only with compreface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for WebP image formats, improving image loading times and reducing file sizes.
	- Introduced a new image loading function that enhances error handling and supports WebP images.

- **Bug Fixes**
	- Improved URL validation to accept WebP image MIME types, broadening the range of acceptable inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->