### PR TITLE
Print nested arrays for logged recognition output

### DIFF
--- a/api/src/controllers/recognize.controller.js
+++ b/api/src/controllers/recognize.controller.js
@@ -175,7 +175,7 @@ module.exports.start = async (req, res) => {
     ['matches', 'misses', 'unknowns'].forEach((type) =>
       loggedOutput[type].forEach((result) => delete result.base64)
     );
-    console.log(loggedOutput);
+    console.log(JSON.stringify(loggedOutput, null, 2)); // Re-Stringify to print nested array values
 
     PROCESSING = false;
 


### PR DESCRIPTION
JSON.stringify the loggedOutput object to keep helpful information like `box` and `checks` in the logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging readability by formatting nested structures in the output for better debugging insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->