### PR TITLE
Fix device_tracker_timeout example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,15 @@ frigate:
     # - camera: garage
     #   zone: driveway
 
+  # This option allows setting a custom time delay for the MQTT home
+  # assistant device tracker.                                                   
+                                                                              
+  # By adjusting  device_tracker_timeout , users can determine how long they    
+  # want to wait before receiving a 'not_home' message when no person is        
+  # recognized. The time delay is implemented in minutes and the default value  
+  # is set to 30 minutes
+  device_tracker_timeout: 30
+
   # override frigate attempts and image per camera
   events:
     # front-door:
@@ -453,15 +462,6 @@ frigate:
     #     latest: http://camera-url.com/image.jpg
     #     # custom image that will be used in place of snapshot.jpg
     #     snapshot: http://camera-url.com/image.jpg
-
-    # This option allows setting a custom time delay for the MQTT home
-    # assistant device tracker.                                                   
-                                                                                
-    # By adjusting  device_tracker_timeout , users can determine how long they    
-    # want to wait before receiving a 'not_home' message when no person is        
-    # recognized. The time delay is implemented in minutes and the default value  
-    # is set to 30 minutes
-    device_tracker_timeout: 30
 ```
 
 ### `cameras`


### PR DESCRIPTION
Fix indentation of `device_tracker_timeout` property in example config in README.

As you can see from the relevant code below, `device_tracker_timeout` is not nested inside the `events` property:
```typescript
module.exports.frigate = ({ id, camera, topic }) => {
  const { topicURL } = require('../util/frigate.util');
  const {
    url,
    events,
    attempts,
    image,
    stop_on_match: stopOnMatch,
    min_area: minArea,
    device_tracker_timeout: deviceTrackerTimeout,
  } = JSON.parse(JSON.stringify(CONFIG.frigate));
  const { masks } = module.exports;

  _.mergeWith(image, events?.[camera]?.image || {}, customizer);
  _.mergeWith(attempts, events?.[camera]?.attempts || {}, customizer);

  const useCrop = masks(camera) || crop_snapshot(camera) ? '' : '&crop=1';
  const snapshot = `${topicURL(topic)}/api/events/${id}/snapshot.jpg?h=${image.height}${useCrop}`;

  const latest = image.latest || `${topicURL(topic)}/api/${camera}/latest.jpg?h=${image.height}`;

  return objectKeysToUpperCase({
    url: { frigate: url, snapshot, latest },
    attempts,
    stop_on_match: stopOnMatch,
    min_area: minArea,
    device_tracker_timeout: deviceTrackerTimeout,
  });
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `device_tracker_timeout`, allowing users to customize the delay for the MQTT home assistant device tracker.
  
- **Documentation**
	- Updated the `README.md` to include the new configuration option and improved clarity of comments related to its purpose and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->