### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,4 +747,4 @@ compreface_key: <api-key>
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=skrashevich/double-take&type=Timeline)](https://star-history.com/#skrashevich/double-take&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=skrashevich/double-take&type=Timeline)](https://star-history.dera.page/#skrashevich/double-take&Timeline)


### PR DESCRIPTION
The Star History chart in the README is currently broken and not rendering. This updates the chart link to a working provider so the visualisation appears correctly again. No other project docs are affected.